### PR TITLE
The error about climate support has been fixed

### DIFF
--- a/.hass/configuration.yaml
+++ b/.hass/configuration.yaml
@@ -14,8 +14,6 @@ scene: !include scenes.yaml
 
 # Load integrations
 demo:
-climate:
-  - platform: demo
 
 # Include extra configuration
 rest: !include rests.yaml


### PR DESCRIPTION
The error: "The demo platform for the climate integration does not support platform setup." has been fixed